### PR TITLE
fix: compat with new ts@4.7's node16 resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   "main": "./dist/marked-react.cjs",
   "module": "./dist/marked-react.js",
   "exports": {
-    ".": "./dist/marked-react.js",
+    ".": {
+      "import":"./dist/marked-react.js",
+      "require": "./dist/marked-react.cjs",
+      "types": "./src/index.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "typings": "./src/index.d.ts",


### PR DESCRIPTION
new typescript version picks up the "types" key instead of the root "typings" when in "node16" resolution mode.
also defined both "require" and "import" bundles so they can be natively required/imported in each mode.