### PR TITLE
Fix ordered list starting number

### DIFF
--- a/src/ReactParser.ts
+++ b/src/ReactParser.ts
@@ -57,7 +57,7 @@ class ReactParser {
             return this.renderer.listItem(listItemChildren);
           });
 
-          return this.renderer.list(children, token.ordered);
+          return this.renderer.list(children, token.ordered, token.ordered ? token.start : undefined);
         }
 
         case 'code': {

--- a/src/ReactRenderer.ts
+++ b/src/ReactRenderer.ts
@@ -95,8 +95,8 @@ class ReactRenderer {
     return this.#h('blockquote', children);
   }
 
-  list(children: ReactNode, ordered: boolean) {
-    return this.#h(ordered ? 'ol' : 'ul', children);
+  list(children: ReactNode, ordered: boolean, start: number | undefined) {
+    return this.#h(ordered ? 'ol' : 'ul', children, ordered ? { start } : {});
   }
 
   listItem(children: ReactNode[]) {

--- a/src/ReactRenderer.ts
+++ b/src/ReactRenderer.ts
@@ -96,7 +96,7 @@ class ReactRenderer {
   }
 
   list(children: ReactNode, ordered: boolean, start: number | undefined) {
-    return this.#h(ordered ? 'ol' : 'ul', children, ordered ? { start } : {});
+    return this.#h(ordered ? 'ol' : 'ul', children, ordered && start !== 1 ? { start } : {});
   }
 
   listItem(children: ReactNode[]) {

--- a/tests/markdown.spec.ts
+++ b/tests/markdown.spec.ts
@@ -86,7 +86,12 @@ const cases = [
   {
     title: 'render ordered lists',
     markdown: '1. option-1\n2. option-2',
-    html: '<ol><li>option-1</li><li>option-2</li></ol>',
+    html: '<ol start="1"><li>option-1</li><li>option-2</li></ol>',
+  },
+  {
+    title: 'render ordered lists with different start value',
+    markdown: '2. option-2\n3. option-3',
+    html: '<ol start="2"><li>option-2</li><li>option-3</li></ol>',
   },
   {
     title: 'render codeblocks',

--- a/tests/markdown.spec.ts
+++ b/tests/markdown.spec.ts
@@ -86,7 +86,7 @@ const cases = [
   {
     title: 'render ordered lists',
     markdown: '1. option-1\n2. option-2',
-    html: '<ol start="1"><li>option-1</li><li>option-2</li></ol>',
+    html: '<ol><li>option-1</li><li>option-2</li></ol>',
   },
   {
     title: 'render ordered lists with different start value',


### PR DESCRIPTION
If the user starts an ordered list with a value other than `1.`, it does not get properly rendered.

This PR utilizes the `token.start` property from Marked and adds it to the `ol` element's `start` attribute so that ordered list is rendered with the correct number. In addition, the existing ordered list test was updated and an additional test was added to cover this specific case.

