### PR TITLE
Fix tokenizer not read when instance provided

### DIFF
--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -45,6 +45,7 @@ const Markdown = (props: MarkdownProps) => {
   const lexerOptions = {
     breaks: options.breaks,
     gfm: options.gfm,
+    tokenizer: marked.defaults.tokenizer,
   };
 
   // convert input markdown into tokens

--- a/tests/component.spec.ts
+++ b/tests/component.spec.ts
@@ -1,6 +1,7 @@
 import { it, expect, describe } from 'vitest';
 import { createElement, ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { Marked } from 'marked';
 
 import Markdown from '../src/index';
 import { CustomReactRenderer, HeadingLevels } from '../src/ReactRenderer';
@@ -16,6 +17,24 @@ describe('Markdown Component', () => {
     const marked = createElement(Markdown, null, '# Hello world!');
     const html = renderToStaticMarkup(marked);
     expect(html).toBe('<h1>Hello world!</h1>');
+  });
+
+  it('should render correctly with custom instance', () => {
+    const instance = new Marked();
+    const marked = createElement(Markdown, { instance }, '# Hello world!');
+    const html = renderToStaticMarkup(marked);
+    expect(html).toBe('<h1>Hello world!</h1>');
+  });
+
+  it('should accept global tokenizer options', () => {
+    const instance = new Marked({
+      tokenizer: {
+        heading: () => undefined,
+      },
+    });
+    const marked = createElement(Markdown, { instance }, '# Hello world!');
+    const html = renderToStaticMarkup(marked);
+    expect(html).toBe('<p># Hello world!</p>');
   });
 
   it('should prefer value over children render markdown correctly', () => {


### PR DESCRIPTION
Hi 👋 🙂 

Firstly, thank you for this library, it's incredibly useful when working with Marked and React.

I am using markdown in an internal component library and we only allow certain syntax. We _could_ use the custom `renderer` prop on marked-react but it doesn't keep the original syntax. This can be a problem for, say, lists where the beginning of the line could be `-` or `*`.

However, `Marked` can be configured to ignore certain syntax completely using the `tokenizer`:

```js
const instance = new Marked({
  tokenizer: {
    list: () => undefined,
  },
});
```

But this currently gets ignored:

```jsx
<Markdown instance={instance} value="* item" />
// -> <ul><li>item</li></ul>
```

`marked-react` doesn't currently use the `tokenizer` global config because the `lexer` ignores it. With a small change to your `lexerOptions` we can make that render correctly:

```jsx
<Markdown instance={instance} value="* item" />
// -> <p>* item</p>
```

Thanks,

Will.

