### PR TITLE
fix(marked-react): add support for unescaping `&nbsp;` and `&#160;` entities

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,10 +4,12 @@ const htmlUnescapes: Record<string, string> = {
   '&gt;': '>',
   '&quot;': '"',
   '&#39;': "'",
+  '&nbsp;': ' ',
+  '&#160;': ' ',
 };
 
 /** Used to match HTML entities and HTML characters. */
-const reEscapedHtml = /&(?:amp|lt|gt|quot|#(?:0+)?39);/g;
+const reEscapedHtml = /&(?:amp|lt|gt|quot|nbsp|#(?:0+)?(?:39|160));/g;
 const reHasEscapedHtml = RegExp(reEscapedHtml.source);
 
 export const unescape = (str = '') => {

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -15,6 +15,8 @@ describe('Helpers', () => {
     expect(unescape('&gt;')).toBe('>');
     expect(unescape('&quot;')).toBe('"');
     expect(unescape('&#39;')).toBe("'");
+    expect(unescape('&nbsp;')).toBe(' ');
+    expect(unescape('&#160;')).toBe(' ');
     expect(unescape('')).toBe('');
     expect(unescape()).toBe('');
   });


### PR DESCRIPTION
Hi!

For our project we noticed that non breaking space characters were still shown plainly. This PR unescapes them (both character and numeric entity) so that they can render correctly.