### PR TITLE
Handle falsy values in prop validation

### DIFF
--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -14,11 +14,11 @@ export interface MarkdownProps extends ReactRendererOptions, LexerOptions {
 }
 
 const validateComponentProps = (props: MarkdownProps) => {
-  if (props.value && typeof props.value !== 'string') {
+  if (props.value != null && typeof props.value !== 'string') {
     throw new TypeError(`[marked-react]: Expected value to be of type string but got ${typeof props.value}`);
   }
 
-  if (props.children && typeof props.children !== 'string') {
+  if (props.children != null && typeof props.children !== 'string') {
     throw new TypeError(`[marked-react]: Expected children to be of type string but got ${typeof props.children}`);
   }
 };

--- a/tests/component.spec.ts
+++ b/tests/component.spec.ts
@@ -44,7 +44,7 @@ describe('Markdown Component', () => {
   });
 
   it('should throw error if children is not a string', () => {
-    const marked = createElement(Markdown, null, 1);
+    const marked = createElement(Markdown, null, 0);
 
     expect(() => renderToStaticMarkup(marked)).toThrowError(
       new TypeError('[marked-react]: Expected children to be of type string but got number'),


### PR DESCRIPTION
The Markdown component checks if the value and children props are strings so it can throw an error if they are not.

However, if a user passed falsy values like 0 or false (which are not strings), the code would fail silently and not raise a TypeError.

Steps to reproduce the bug:

Pass 0 or false to the Markdown component as a prop or child.
(Example: const marked = createElement(Markdown, null, 0);)